### PR TITLE
fix: Correct parameter name

### DIFF
--- a/V1(deprecated)/buyNftFromAnyChain/src/index.ts
+++ b/V1(deprecated)/buyNftFromAnyChain/src/index.ts
@@ -73,7 +73,7 @@ const getSDK = () => {
     quantity: 1,
     maxPricePerItem: "990000000000000000",
     paymentToken: magicToken,
-    usinEth: false,
+    usingEth: false,
   };
   const buyMoonRockNftEncodeData =
     treasureMarketplaceInterface.encodeFunctionData("buyItems", [

--- a/V2/sdk/oldExamples/buyNftFromAnyChain/src/index.ts
+++ b/V2/sdk/oldExamples/buyNftFromAnyChain/src/index.ts
@@ -74,7 +74,7 @@ const getSDK = () => {
     quantity: 1,
     maxPricePerItem: "990000000000000000",
     paymentToken: magicToken,
-    usinEth: false,
+    usingEth: false,
   };
   const buyMoonRockNftEncodeData =
     treasureMarketplaceInterface.encodeFunctionData("buyItems", [


### PR DESCRIPTION
This PR fixes a typo in the parameter name for NFT purchase parameters across both V1 and V2 implementations.

Changes made:
- Changed parameter name from 'usinEth' to 'usingEth' in both V1 and V2 index.ts files
- This aligns with the correct parameter name defined in the Treasure Marketplace ABI (treasureMarketplaceAbi.ts)
![image](https://github.com/user-attachments/assets/a87c33b5-4f2b-4f29-938b-0636fb5761c7)
