### PR TITLE
feat: update xrplToArbitrumSwap examples for native XRP swaps

### DIFF
--- a/V2/api/xrplToArbitrumSwap/package-lock.json
+++ b/V2/api/xrplToArbitrumSwap/package-lock.json
@@ -10,7 +10,8 @@
 				"dotenv": "^16.4.5",
 				"ts-node": "^10.9.2",
 				"typescript": "^5.3.3",
-				"xrpl": "^3.0.0"
+				"xrpl": "^3.0.0",
+				"xrpl-secret-numbers": "^0.3.5"
 			}
 		},
 		"node_modules/@cspotcode/source-map-support": {
@@ -124,11 +125,19 @@
 			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
 			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
 		},
+		"node_modules/@types/brorand": {
+			"version": "1.0.33",
+			"resolved": "https://registry.npmjs.org/@types/brorand/-/brorand-1.0.33.tgz",
+			"integrity": "sha512-KmNsWYtzKXpmxjecvYWUEGK5biJB/1kpHRObHZD8eme1tz/TvbESbZeNAHPRNd5qyCJiHk2ztbNzKbPC6TuPFg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/node": {
 			"version": "25.5.2",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
 			"integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.18.0"
 			}
@@ -209,6 +218,12 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+			"license": "MIT"
 		},
 		"node_modules/call-bind-apply-helpers": {
 			"version": "1.0.2",
@@ -615,8 +630,7 @@
 		"node_modules/undici-types": {
 			"version": "7.18.2",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-			"peer": true
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
 		},
 		"node_modules/v8-compile-cache-lib": {
 			"version": "3.0.1",
@@ -675,6 +689,17 @@
 			},
 			"engines": {
 				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/xrpl-secret-numbers": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/xrpl-secret-numbers/-/xrpl-secret-numbers-0.3.5.tgz",
+			"integrity": "sha512-5W2Ijp4nFpplEJ4IEK8JNAnRN9+3/+8BdBQ0hOZ3bZfa/+K9c9GNdN5fHDkKoECJN3nzXNcj6/Ejg7wUQDtRnQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/brorand": "^1.0.30",
+				"brorand": "^1.1.0",
+				"ripple-keypairs": "^2.0.0"
 			}
 		},
 		"node_modules/yn": {

--- a/V2/api/xrplToArbitrumSwap/package.json
+++ b/V2/api/xrplToArbitrumSwap/package.json
@@ -7,7 +7,8 @@
 		"dotenv": "^16.4.5",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.3.3",
-		"xrpl": "^3.0.0"
+		"xrpl": "^3.0.0",
+		"xrpl-secret-numbers": "^0.3.5"
 	},
 	"license": "MIT"
 }

--- a/V2/api/xrplToArbitrumSwap/src/index.ts
+++ b/V2/api/xrplToArbitrumSwap/src/index.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import * as dotenv from "dotenv";
 import * as xrpl from "xrpl"; // Import xrpl library for native XRPL logic
+import { Account } from "xrpl-secret-numbers"; // Import Xaman secret number converter
 dotenv.config();
 
 // Load environment variables from .env file
@@ -14,15 +15,30 @@ if (!xrplSeed || !integratorId) {
 
 // Define parameters from the provided payload
 const fromChainId = "xrpl-mainnet";
-const fromToken = "5553444300000000000000000000000000000000.rGm7WCVp9gb4jZHWTEtGUr4dd74z2XuWhE"; // RLUSD
-const fromAmount = "10000000000000000";
+const fromToken = "xrp"; // Native XRP
+const fromAmount = "10000";
 
 const toChainId = "42161"; // Arbitrum
 const toToken = "0xaf88d065e77c8cc2239327c5edb3a432268e5831"; // USDC on Arbitrum
 
+const quoteOnly = false;
+
 // Set up XRPL public client and wallet
 const XRPL_RPC = "wss://s1.ripple.com/"; // XRPL Mainnet Websocket RPC
-const wallet = xrpl.Wallet.fromSeed(xrplSeed);
+
+// Detect if the seed is a Xaman secret number (contains spaces) or a standard base58 seed
+let wallet: xrpl.Wallet;
+if (xrplSeed.includes(" ")) {
+  // Convert Xaman secret numbers (8 groups of 6 digits) to a family seed
+  const account = new Account(xrplSeed);
+  const familySeed = account.getFamilySeed();
+  const keypair = account.getKeypair();
+  console.log("Derived XRPL address from secret numbers:", account.getAddress());
+  // Build wallet from the keypair to ensure address consistency
+  wallet = new xrpl.Wallet(keypair.publicKey, keypair.privateKey);
+} else {
+  wallet = xrpl.Wallet.fromSeed(xrplSeed);
+}
 
 // Function to get the optimal route for the swap using Squid API
 const getRoute = async (params: any) => {
@@ -110,21 +126,15 @@ const updateTransactionStatus = async (txHash: string, requestId: string, quoteI
 
 // Main function
 (async () => {
-  const xrplClient = new xrpl.Client(XRPL_RPC);
-  await xrplClient.connect();
-  console.log(`Connected to XRPL: ${xrplClient.isConnected()}`);
-
   const params = {
-    // using user wallet address automatically derived from the XRPL seed
     fromAddress: wallet.address,
     fromChain: fromChainId,
     fromToken: fromToken,
     fromAmount: fromAmount,
     toChain: toChainId,
     toToken: toToken,
-    // toAddress can be any EVM address. For this example we just pass a placeholder Arbitrum address
-    toAddress: "0x0c9aB9754FAd739b167a338B99D37B21872BfeDb", 
-    quoteOnly: false
+    toAddress: "0x0c9aB9754FAd739b167a338B99D37B21872BfeDb",
+    quoteOnly: quoteOnly
   };
 
   console.log("Parameters:", params);
@@ -140,38 +150,53 @@ const updateTransactionStatus = async (txHash: string, requestId: string, quoteI
   console.log("Calculated route... target output:", route.estimate.toAmount);
   console.log("requestId:", requestId);
 
-  const transactionRequest = route.transactionRequest;
+  if (quoteOnly) {
+    // Quote-only mode: display the quote details and exit
+    console.log("\n=== Quote Details ===");
+    console.log("From:", fromAmount, fromToken, "on", fromChainId);
+    console.log("To:", route.estimate.toAmount, toToken, "on", toChainId);
+    console.log("Estimated USD value:", route.estimate.toAmountUSD || "N/A");
+    console.log("quoteId:", quoteId);
+    console.log("Quote-only mode — no transaction executed.");
+  } else {
+    // Full execution mode: connect to XRPL and submit the transaction
+    const xrplClient = new xrpl.Client(XRPL_RPC);
+    await xrplClient.connect();
+    console.log(`Connected to XRPL: ${xrplClient.isConnected()}`);
 
-  // Execute the swap transaction natively on XRPL
-  // route.transactionRequest.data contains the exact XRPL Payment struct, with Memos already prepared
-  console.log(`Preparing XRPL transaction for ${transactionRequest.target}...`);
-  const txJson = transactionRequest.data;
-  
-  // Update the sender explicitly just in case it's not dynamically matched to the wallet yet
-  txJson.Account = wallet.address;
+    const transactionRequest = route.transactionRequest;
 
-  // Autofill missing fields (such as Fee, Sequence, etc.)
-  const prepared = await xrplClient.autofill(txJson);
-  
-  // Sign the transaction
-  const signed = wallet.sign(prepared);
-  
-  console.log("Submitting transaction payload to XRPL...");
-  
-  // Submit the transaction and wait for ledger validation
-  const txResult = await xrplClient.submitAndWait(signed.tx_blob);
-  
-  const txHash = txResult.result.hash;
-  console.log("Transaction Mined in XRPL ledger! Hash:", txHash);
+    // Execute the swap transaction natively on XRPL
+    // route.transactionRequest.data contains the exact XRPL Payment struct, with Memos already prepared
+    console.log(`Preparing XRPL transaction for ${transactionRequest.target}...`);
+    const txJson = transactionRequest.data;
+    
+    // Update the sender explicitly just in case it's not dynamically matched to the wallet yet
+    txJson.Account = wallet.address;
 
-  // We can track the transaction natively on XRPL via livenet block explorers
-  const xrplBithompLink = "https://bithomp.com/explorer/" + txHash;
-  console.log(`Check transaction details: ${xrplBithompLink}`);
+    // Autofill missing fields (such as Fee, Sequence, etc.)
+    const prepared = await xrplClient.autofill(txJson);
+    
+    // Sign the transaction
+    const signed = wallet.sign(prepared);
+    
+    console.log("Submitting transaction payload to XRPL...");
+    
+    // Submit the transaction and wait for ledger validation
+    const txResult = await xrplClient.submitAndWait(signed.tx_blob);
+    
+    const txHash = txResult.result.hash;
+    console.log("Transaction Mined in XRPL ledger! Hash:", txHash);
 
-  // Update transaction status until it completes, ensuring the quoteId is passed for Coral V2 checks
-  // Note: XRPL native deposits do not depend on depositTxVerificationSignature
-  await updateTransactionStatus(txHash, requestId as string, quoteId);
+    // We can track the transaction natively on XRPL via livenet block explorers
+    const squidScanLink = "https://scan.squidrouter.com/tx/" + txHash;
+    console.log(`Check Coralscan for details: ${squidScanLink}`);
 
-  // Clean up client connection
-  await xrplClient.disconnect();
+    // Update transaction status until it completes, ensuring the quoteId is passed for Coral V2 checks
+    // Note: XRPL native deposits do not depend on depositTxVerificationSignature
+    await updateTransactionStatus(txHash, requestId as string, quoteId);
+
+    // Clean up client connection
+    await xrplClient.disconnect();
+  }
 })();

--- a/V2/sdk/xrplToArbitrumSwap/package-lock.json
+++ b/V2/sdk/xrplToArbitrumSwap/package-lock.json
@@ -11,9 +11,7 @@
 				"dotenv": "^16.4.5",
 				"ts-node": "^10.9.2",
 				"typescript": "^5.3.3",
-				"xrpl": "^3.0.0"
-			},
-			"devDependencies": {
+				"xrpl": "^3.0.0",
 				"xrpl-secret-numbers": "^0.3.5"
 			}
 		},
@@ -714,7 +712,6 @@
 			"version": "1.0.33",
 			"resolved": "https://registry.npmjs.org/@types/brorand/-/brorand-1.0.33.tgz",
 			"integrity": "sha512-KmNsWYtzKXpmxjecvYWUEGK5biJB/1kpHRObHZD8eme1tz/TvbESbZeNAHPRNd5qyCJiHk2ztbNzKbPC6TuPFg==",
-			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -2219,7 +2216,6 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/xrpl-secret-numbers/-/xrpl-secret-numbers-0.3.5.tgz",
 			"integrity": "sha512-5W2Ijp4nFpplEJ4IEK8JNAnRN9+3/+8BdBQ0hOZ3bZfa/+K9c9GNdN5fHDkKoECJN3nzXNcj6/Ejg7wUQDtRnQ==",
-			"dev": true,
 			"dependencies": {
 				"@types/brorand": "^1.0.30",
 				"brorand": "^1.1.0",

--- a/V2/sdk/xrplToArbitrumSwap/package.json
+++ b/V2/sdk/xrplToArbitrumSwap/package.json
@@ -8,10 +8,8 @@
 		"dotenv": "^16.4.5",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.3.3",
-		"xrpl": "^3.0.0"
-	},
-	"license": "MIT",
-	"devDependencies": {
+		"xrpl": "^3.0.0",
 		"xrpl-secret-numbers": "^0.3.5"
-	}
+	},
+	"license": "MIT"
 }

--- a/V2/sdk/xrplToArbitrumSwap/src/index.ts
+++ b/V2/sdk/xrplToArbitrumSwap/src/index.ts
@@ -1,6 +1,7 @@
 import { Squid } from "@0xsquid/sdk";
 import * as dotenv from "dotenv";
 import * as xrpl from "xrpl"; // Import native XRPL SDK
+import { Account } from "xrpl-secret-numbers"; // Import Xaman secret number converter
 dotenv.config();
 
 // Retrieve environment variables
@@ -14,15 +15,27 @@ if (!xrplSeed || !integratorId) {
 
 // Define parameters from the provided payload
 const fromChainId = "xrpl-mainnet";
-const fromToken = "524C555344000000000000000000000000000000.rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De"; // RLUSD
-const fromAmount = "1000000000000000"; // 1.0 RLUSD
+const fromToken = "xrp"; // Native XRP
+const fromAmount = "10000";
 
 const toChainId = "42161"; // Arbitrum
 const toToken = "0xaf88d065e77c8cc2239327c5edb3a432268e5831"; // USDC on Arbitrum
 
 // Set up XRPL public client and wallet
 const XRPL_RPC = "wss://s1.ripple.com/"; 
-const wallet = xrpl.Wallet.fromSeed(xrplSeed);
+
+// Detect if the seed is a Xaman secret number (contains spaces) or a standard base58 seed
+let wallet: xrpl.Wallet;
+if (xrplSeed.includes(" ")) {
+  // Convert Xaman secret numbers (8 groups of 6 digits) to a family seed
+  const account = new Account(xrplSeed);
+  const keypair = account.getKeypair();
+  console.log("Derived XRPL address from secret numbers:", account.getAddress());
+  // Build wallet from the keypair to ensure address consistency
+  wallet = new xrpl.Wallet(keypair.publicKey, keypair.privateKey);
+} else {
+  wallet = xrpl.Wallet.fromSeed(xrplSeed);
+}
 
 // Initialize the Squid client with the base URL and integrator ID
 const getSDK = (): Squid => {
@@ -101,8 +114,8 @@ const getSDK = (): Squid => {
   const txHash = txResult.result.hash;
   console.log("Transaction Mined in XRPL ledger! Hash:", txHash);
 
-  const xrplBithompLink = "https://bithomp.com/explorer/" + txHash;
-  console.log(`Check transaction details natively: ${xrplBithompLink}`);
+  const squidScanLink = "https://scan.squidrouter.com/tx/" + txHash;
+  console.log(`Check Coralscan for details: ${squidScanLink}`);
 
   // Parameters for checking the status of the transaction via Squid SDK
   const getStatusParams: any = {


### PR DESCRIPTION
- Update fromToken to native XRP ('xrp') with fromAmount '10000'
- Add xrpl-secret-numbers dependency for proper Xaman secret number wallet derivation
- Fix wallet address derivation using Account keypair for consistency
- Update explorer links from Bithomp to Coralscan (scan.squidrouter.com)
- Add quoteOnly branching logic in API example
- Applied changes to both API and SDK examples